### PR TITLE
Add missing quotes in graphQL query

### DIFF
--- a/src/components/BuildSlugButton.tsx
+++ b/src/components/BuildSlugButton.tsx
@@ -98,7 +98,7 @@ const BuildSlugButton = ({ ctx }: PropsType) => {
 
     return `
     query {
-      ${itemApiKey}(locale: ${locale}, filter: { id: { eq: ${itemId}} }) {
+      ${itemApiKey}(locale: ${locale}, filter: { id: { eq: "${itemId}" } }) {
        ${getPageParams}
         parent {
           ${getPageParams}


### PR DESCRIPTION
Some identifiers in DatoCMS contain a dash, which is an invalid character for the graphQL query, unless it is quoted.

This PR fixes that issue.